### PR TITLE
Adding first approach of the Intent Recognizer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,6 @@
 *.exe
 *.out
 *.app
+
+**/build
+**/bin

--- a/EmbeddedIntentRecognizer/CMakeLists.txt
+++ b/EmbeddedIntentRecognizer/CMakeLists.txt
@@ -1,0 +1,9 @@
+cmake_minimum_required(VERSION 3.5)
+project(IntentRecognizer)
+
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++14 -Wall -Wextra")
+
+set(CMAKE_RUNTIME_OUTPUT_DIRECTORY ${CMAKE_SOURCE_DIR}/bin)
+
+add_subdirectory(src)
+add_subdirectory(test)

--- a/EmbeddedIntentRecognizer/src/CMakeLists.txt
+++ b/EmbeddedIntentRecognizer/src/CMakeLists.txt
@@ -1,0 +1,4 @@
+cmake_minimum_required(VERSION 3.5)
+project(IntentRecognizer)
+
+add_executable(console_application program.cpp)

--- a/EmbeddedIntentRecognizer/src/CMakeLists.txt
+++ b/EmbeddedIntentRecognizer/src/CMakeLists.txt
@@ -1,4 +1,6 @@
 cmake_minimum_required(VERSION 3.5)
 project(IntentRecognizer)
 
-add_executable(console_application program.cpp)
+add_executable(console_application Program.cpp IntentRecognizer.cpp Console.cpp)
+
+target_include_directories(console_application PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/EmbeddedIntentRecognizer/src/Console.cpp
+++ b/EmbeddedIntentRecognizer/src/Console.cpp
@@ -1,0 +1,30 @@
+
+#include "Console.h"
+
+using namespace Utils;
+
+Console* Console::consoleSingleton = 0;
+
+Console* Console::Get() {
+    if(consoleSingleton == 0){
+        consoleSingleton = new Console();
+    }
+
+    return consoleSingleton;
+}
+
+Console::~Console() = default;
+
+void Console::DisplayMessage(const std::string& message) {
+    printf("%s\n", message.c_str());
+}
+
+std::string Console::ReadUserInput() {
+    std::string userInput;
+    std::getline(std::cin, userInput);
+    return userInput;
+}
+
+void Console::ClearConsole() {
+    printf("\033c");
+}

--- a/EmbeddedIntentRecognizer/src/Console.cpp
+++ b/EmbeddedIntentRecognizer/src/Console.cpp
@@ -15,16 +15,20 @@ Console* Console::Get() {
 
 Console::~Console() = default;
 
-void Console::DisplayMessage(const std::string& message) {
-    printf("%s\n", message.c_str());
+void Console::DisplayMessage(const std::string& message) const {
+    printf("\033[3;47;35m%s\033[0m\n", message.c_str());
 }
 
-std::string Console::ReadUserInput() {
+void Console::DisplayBlankLine() const {
+    printf("\n");
+}
+
+std::string Console::ReadUserInput() const {
     std::string userInput;
     std::getline(std::cin, userInput);
     return userInput;
 }
 
-void Console::ClearConsole() {
+void Console::ClearConsole() const {
     printf("\033c");
 }

--- a/EmbeddedIntentRecognizer/src/Console.h
+++ b/EmbeddedIntentRecognizer/src/Console.h
@@ -10,9 +10,10 @@ public:
     static Console* Get();
     ~Console();
 
-    void DisplayMessage(const std::string& message);
-    std::string ReadUserInput();
-    void ClearConsole();
+    void DisplayMessage(const std::string& message) const;
+    void DisplayBlankLine() const;
+    std::string ReadUserInput() const;
+    void ClearConsole() const;
 
 private:
     Console() {}

--- a/EmbeddedIntentRecognizer/src/Console.h
+++ b/EmbeddedIntentRecognizer/src/Console.h
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <iostream>
+#include <string>
+
+namespace Utils {
+
+class Console {
+public:
+    static Console* Get();
+    ~Console();
+
+    void DisplayMessage(const std::string& message);
+    std::string ReadUserInput();
+    void ClearConsole();
+
+private:
+    Console() {}
+
+    static Console* consoleSingleton;
+};
+
+} // namespace Utilss

--- a/EmbeddedIntentRecognizer/src/IntentRecognizer.cpp
+++ b/EmbeddedIntentRecognizer/src/IntentRecognizer.cpp
@@ -2,7 +2,48 @@
 
 using namespace ConsoleIntentRecognizer;
 
-IntentRecognizer::IntentRecognizer() = default;
+NlpWrapper::NlpWrapper() = default;
+
+NlpWrapper::~NlpWrapper() = default;
+
+IntentActions NlpWrapper::CategorizeAction(const std::string& /*input*/) const {
+    return UNSUPPORTED;
+}
+
+IntentExecutor::IntentExecutor() = default;
+
+IntentExecutor::~IntentExecutor() = default;
+
+std::string IntentExecutor::Execute(const IntentActions& action) const {
+    std::string result;
+    switch(action) {
+        case WEATHER: {
+            result = "Intent: Get Weather";
+            break;
+        }
+        case CITY_WEATHER: {
+            result = "Intent: Get Weather City";
+            break;
+        }
+        case FACT: {
+            result = "Intent: Get Fact";
+            break;
+        }
+        case UNSUPPORTED:
+        default: {
+            result = "Intent: Unsupported";
+            break;
+        }
+    }
+    return result;
+}
+
+IntentRecognizer::IntentRecognizer() : intentExecutor(std::make_unique<IntentExecutor>()),
+                                       nlpWrapper(std::make_unique<NlpWrapper>()) {}
+
 IntentRecognizer::~IntentRecognizer() = default;
 
-std::string IntentRecognizer::Process(const std::string& /*input*/) { return ""; }
+std::string IntentRecognizer::Process(const std::string& input) {
+    const auto actionToExecute = nlpWrapper->CategorizeAction(input);
+    return intentExecutor->Execute(actionToExecute);
+}

--- a/EmbeddedIntentRecognizer/src/IntentRecognizer.cpp
+++ b/EmbeddedIntentRecognizer/src/IntentRecognizer.cpp
@@ -1,4 +1,7 @@
+#include<algorithm>
+
 #include "IntentRecognizer.h"
+#include "Utils.h"
 
 using namespace ConsoleIntentRecognizer;
 
@@ -6,8 +9,48 @@ NlpWrapper::NlpWrapper() = default;
 
 NlpWrapper::~NlpWrapper() = default;
 
-IntentActions NlpWrapper::CategorizeAction(const std::string& /*input*/) const {
-    return UNSUPPORTED;
+bool NlpWrapper::MatchesKeyWords(const std::vector<std::string>& keyWords,
+                                 const std::vector<std::string>& itemsToVerify) const {
+    return std::all_of(std::begin(keyWords), std::end(keyWords),
+                       [itemsToVerify](const std::string& item){ return Utils::Utils::Contains(itemsToVerify, item); });
+}
+
+bool NlpWrapper::IsFact(const std::vector<std::string>& items) const {
+    const std::vector<std::string> keyWords = {"fact", "tell"};
+    return MatchesKeyWords(keyWords, items);
+}
+
+bool NlpWrapper::IsWeather(const std::vector<std::string>& items) const {
+    const std::vector<std::string> keyWords = {"weather", "what"};
+    return MatchesKeyWords(keyWords, items);
+}
+
+bool NlpWrapper::IsWeatherCity(const std::vector<std::string>& items) const {
+    const std::vector<std::string> keyWords = {"weather", "what", "in"};
+    return MatchesKeyWords(keyWords, items);
+}
+
+IntentActions NlpWrapper::CategorizeAction(const std::string& input) const {
+    const auto inputItems = Utils::Utils::Split(Utils::Utils::RemoveSpecialCharacters(input));
+    std::vector<std::string> inputLowerItems;
+    std::transform(inputItems.begin(), inputItems.end(), std::inserter(inputLowerItems, inputLowerItems.begin()),
+                   [](const std::string& name) { return Utils::Utils::ToLower(name); });
+
+    IntentActions result;
+    if(IsFact(inputLowerItems)){
+        result = FACT;
+    }
+    else if (IsWeatherCity(inputLowerItems)) {
+        result = CITY_WEATHER;
+    }
+    else if (IsWeather(inputLowerItems)) {
+        result = WEATHER;
+    }
+    else {
+        result = UNSUPPORTED;
+    }
+
+    return result;
 }
 
 IntentExecutor::IntentExecutor() = default;

--- a/EmbeddedIntentRecognizer/src/IntentRecognizer.cpp
+++ b/EmbeddedIntentRecognizer/src/IntentRecognizer.cpp
@@ -1,0 +1,8 @@
+#include "IntentRecognizer.h"
+
+using namespace ConsoleIntentRecognizer;
+
+IntentRecognizer::IntentRecognizer() = default;
+IntentRecognizer::~IntentRecognizer() = default;
+
+std::string IntentRecognizer::Process(const std::string& /*input*/) { return ""; }

--- a/EmbeddedIntentRecognizer/src/IntentRecognizer.h
+++ b/EmbeddedIntentRecognizer/src/IntentRecognizer.h
@@ -1,0 +1,15 @@
+#pragma once
+
+#include <string>
+
+namespace ConsoleIntentRecognizer {
+
+class IntentRecognizer {
+public:
+    IntentRecognizer();
+    ~IntentRecognizer();
+
+    std::string Process(const std::string& input);
+};
+
+} // namespace ConsoleIntentRecognizer

--- a/EmbeddedIntentRecognizer/src/IntentRecognizer.h
+++ b/EmbeddedIntentRecognizer/src/IntentRecognizer.h
@@ -1,18 +1,27 @@
 #pragma once
 
 #include <string>
+#include <vector>
 #include <memory>
 
 namespace ConsoleIntentRecognizer {
 
 enum IntentActions { WEATHER, CITY_WEATHER, FACT, UNSUPPORTED };
 
+// TODO(bjmorera): Integrate a third party nlp
 class NlpWrapper {
 public:
     NlpWrapper();
     ~NlpWrapper();
 
     IntentActions CategorizeAction(const std::string& input) const;
+
+private:
+    bool MatchesKeyWords(const std::vector<std::string>& keyWords,
+                         const std::vector<std::string>& itemsToVerify) const;
+    bool IsFact(const std::vector<std::string>& items) const;
+    bool IsWeather(const std::vector<std::string>& items) const;
+    bool IsWeatherCity(const std::vector<std::string>& items) const;
 };
 
 class IntentExecutor {

--- a/EmbeddedIntentRecognizer/src/IntentRecognizer.h
+++ b/EmbeddedIntentRecognizer/src/IntentRecognizer.h
@@ -1,8 +1,27 @@
 #pragma once
 
 #include <string>
+#include <memory>
 
 namespace ConsoleIntentRecognizer {
+
+enum IntentActions { WEATHER, CITY_WEATHER, FACT, UNSUPPORTED };
+
+class NlpWrapper {
+public:
+    NlpWrapper();
+    ~NlpWrapper();
+
+    IntentActions CategorizeAction(const std::string& input) const;
+};
+
+class IntentExecutor {
+public:
+    IntentExecutor();
+    ~IntentExecutor();
+
+    std::string Execute(const IntentActions& action) const;
+};
 
 class IntentRecognizer {
 public:
@@ -10,6 +29,10 @@ public:
     ~IntentRecognizer();
 
     std::string Process(const std::string& input);
+
+private:
+    std::unique_ptr<IntentExecutor> intentExecutor;
+    std::unique_ptr<NlpWrapper> nlpWrapper;
 };
 
 } // namespace ConsoleIntentRecognizer

--- a/EmbeddedIntentRecognizer/src/Program.cpp
+++ b/EmbeddedIntentRecognizer/src/Program.cpp
@@ -15,16 +15,16 @@ int main(){
     ConsoleIntentRecognizer::IntentRecognizer intentRecognizer;
 
     while(!exitCondition){
-        Utils::Console::Get()->ClearConsole();
-        Utils::Console::Get()->DisplayMessage("Input: ");
-        const auto userInput = Utils::Console::Get()->ReadUserInput();
+        Utils::Console::Get()->DisplayMessage("Input:");
+        const auto userInput = ToLower(Utils::Console::Get()->ReadUserInput());
 
-        if("exit" == ToLower(userInput)) {
+        if("exit" == userInput) {
             exitCondition = true;
         }
-        else {
+        else if (0 < userInput.length()) {
             const auto result = intentRecognizer.Process(userInput);
             Utils::Console::Get()->DisplayMessage(result);
+            Utils::Console::Get()->DisplayBlankLine();
         }
     }
     return 0;

--- a/EmbeddedIntentRecognizer/src/Program.cpp
+++ b/EmbeddedIntentRecognizer/src/Program.cpp
@@ -1,0 +1,31 @@
+#include <string>
+#include <algorithm>
+
+#include "Console.h"
+#include "IntentRecognizer.h"
+
+std::string ToLower(const std::string& input){
+    std::string copy = input;
+    std::for_each(copy.begin(), copy.end(), [](char & c){c = ::tolower(c);});
+    return copy;
+}
+
+int main(){
+    auto exitCondition = false;
+    ConsoleIntentRecognizer::IntentRecognizer intentRecognizer;
+
+    while(!exitCondition){
+        Utils::Console::Get()->ClearConsole();
+        Utils::Console::Get()->DisplayMessage("Input: ");
+        const auto userInput = Utils::Console::Get()->ReadUserInput();
+
+        if("exit" == ToLower(userInput)) {
+            exitCondition = true;
+        }
+        else {
+            const auto result = intentRecognizer.Process(userInput);
+            Utils::Console::Get()->DisplayMessage(result);
+        }
+    }
+    return 0;
+}

--- a/EmbeddedIntentRecognizer/src/Program.cpp
+++ b/EmbeddedIntentRecognizer/src/Program.cpp
@@ -1,14 +1,8 @@
 #include <string>
-#include <algorithm>
 
+#include "Utils.h"
 #include "Console.h"
 #include "IntentRecognizer.h"
-
-std::string ToLower(const std::string& input){
-    std::string copy = input;
-    std::for_each(copy.begin(), copy.end(), [](char & c){c = ::tolower(c);});
-    return copy;
-}
 
 int main(){
     auto exitCondition = false;
@@ -16,7 +10,7 @@ int main(){
 
     while(!exitCondition){
         Utils::Console::Get()->DisplayMessage("Input:");
-        const auto userInput = ToLower(Utils::Console::Get()->ReadUserInput());
+        const auto userInput = Utils::Utils::ToLower(Utils::Console::Get()->ReadUserInput());
 
         if("exit" == userInput) {
             exitCondition = true;

--- a/EmbeddedIntentRecognizer/src/Utils.h
+++ b/EmbeddedIntentRecognizer/src/Utils.h
@@ -1,0 +1,48 @@
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <sstream>
+#include <vector>
+
+namespace Utils {
+
+class Utils {
+public:
+    static std::string ToLower(const std::string& input);
+    static std::vector<std::string> Split(const std::string& input, char delim = ' ');
+    static bool Contains(const std::vector<std::string>& input, const std::string& search);
+    static std::string RemoveSpecialCharacters(const std::string& input);
+};
+
+inline std::string Utils::ToLower(const std::string& input) {
+    std::string copy = input;
+    std::for_each(copy.begin(), copy.end(), [](char & c){c = ::tolower(c);});
+    return copy;
+}
+
+inline std::vector<std::string> Utils::Split(const std::string& input, char delim) {
+    std::vector<std::string> output;
+    std::stringstream copy(input);
+    std::string itemResult;
+    while (std::getline(copy, itemResult, delim)) {
+        output.push_back(itemResult);
+    }
+    return output;
+}
+
+inline bool Utils::Contains(const std::vector<std::string>& input, const std::string& search)
+{
+    return std::find(input.begin(), input.end(), search) != input.end();
+}
+
+inline std::string Utils::RemoveSpecialCharacters(const std::string& input) {
+    auto copy = input;
+    const std::vector<char> specialCharacters = {',', '.', '?', ';'};
+    for (const auto& character : specialCharacters) {
+        copy.erase(std::remove(copy.begin(), copy.end(), character), copy.end());
+    }
+    return copy;
+}
+
+} // namespace Utils

--- a/EmbeddedIntentRecognizer/src/program.cpp
+++ b/EmbeddedIntentRecognizer/src/program.cpp
@@ -1,0 +1,5 @@
+#include <iostream>
+
+int main(){
+    return 0;
+}

--- a/EmbeddedIntentRecognizer/src/program.cpp
+++ b/EmbeddedIntentRecognizer/src/program.cpp
@@ -1,5 +1,0 @@
-#include <iostream>
-
-int main(){
-    return 0;
-}

--- a/EmbeddedIntentRecognizer/test/CMakeLists.txt
+++ b/EmbeddedIntentRecognizer/test/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 project(IntentRecognizer)
 
-add_executable(IntentRecognizerUnitTest IntentRecognizerUnitTest.cpp)
+add_executable(IntentRecognizerUnitTest IntentRecognizerUnitTest.cpp ${CMAKE_SOURCE_DIR}/src/IntentRecognizer.cpp)
 
 target_compile_options(IntentRecognizerUnitTest PRIVATE -Wall -Wextra)
 

--- a/EmbeddedIntentRecognizer/test/CMakeLists.txt
+++ b/EmbeddedIntentRecognizer/test/CMakeLists.txt
@@ -1,0 +1,8 @@
+cmake_minimum_required(VERSION 3.5)
+project(IntentRecognizer)
+
+add_executable(IntentRecognizerUnitTest IntentRecognizerUnitTest.cpp)
+
+target_compile_options(IntentRecognizerUnitTest PRIVATE -Wall -Wextra)
+
+target_include_directories(IntentRecognizerUnitTest PRIVATE ${CMAKE_SOURCE_DIR}/src)

--- a/EmbeddedIntentRecognizer/test/IntentRecognizerUnitTest.cpp
+++ b/EmbeddedIntentRecognizer/test/IntentRecognizerUnitTest.cpp
@@ -1,0 +1,6 @@
+#define CATCH_CONFIG_MAIN
+#include <catch2/catch.hpp>
+
+TEST_CASE( "Dummy Test", "Dummy" ) {
+    REQUIRE( true );
+}

--- a/EmbeddedIntentRecognizer/test/IntentRecognizerUnitTest.cpp
+++ b/EmbeddedIntentRecognizer/test/IntentRecognizerUnitTest.cpp
@@ -1,6 +1,41 @@
 #define CATCH_CONFIG_MAIN
+
 #include <catch2/catch.hpp>
 
-TEST_CASE( "Dummy Test", "Dummy" ) {
-    REQUIRE( true );
+#include <IntentRecognizer.h>
+
+TEST_CASE("Intent Executor returns actions", "[Intent-Executor]" ) {
+    ConsoleIntentRecognizer::IntentExecutor intentExecutor;
+
+    SECTION("Weather") {
+        REQUIRE("Intent: Get Weather" == intentExecutor.Execute(ConsoleIntentRecognizer::WEATHER));
+    }
+
+    SECTION("Weather City") {
+        REQUIRE("Intent: Get Weather City" == intentExecutor.Execute(ConsoleIntentRecognizer::CITY_WEATHER));
+    }
+
+    SECTION("Fact") {
+        REQUIRE("Intent: Get Fact" == intentExecutor.Execute(ConsoleIntentRecognizer::FACT));
+    }
+
+    SECTION("Unsupported") {
+        REQUIRE("Intent: Unsupported" == intentExecutor.Execute(ConsoleIntentRecognizer::UNSUPPORTED));
+    }
+}
+
+TEST_CASE("NLP Wrapper categorizes actions", "[NLP-Wrapper]" ) {
+    ConsoleIntentRecognizer::NlpWrapper nlpWrapper;
+
+    SECTION("Weather") {
+        REQUIRE(ConsoleIntentRecognizer::UNSUPPORTED == nlpWrapper.CategorizeAction("What is the weather like today?"));
+    }
+
+    SECTION("Weather City") {
+        REQUIRE(ConsoleIntentRecognizer::UNSUPPORTED == nlpWrapper.CategorizeAction("What is the weather like in Paris today?"));
+    }
+
+    SECTION("Fact") {
+        REQUIRE(ConsoleIntentRecognizer::UNSUPPORTED == nlpWrapper.CategorizeAction("Tell me an interesting fact."));
+    }
 }

--- a/EmbeddedIntentRecognizer/test/IntentRecognizerUnitTest.cpp
+++ b/EmbeddedIntentRecognizer/test/IntentRecognizerUnitTest.cpp
@@ -3,6 +3,121 @@
 #include <catch2/catch.hpp>
 
 #include <IntentRecognizer.h>
+#include <Utils.h>
+
+TEST_CASE("Utils ToLower") {
+    SECTION("Empty string case") {
+        REQUIRE("" == Utils::Utils::ToLower(""));
+    }
+
+    SECTION("Only one letter case") {
+        REQUIRE("a" == Utils::Utils::ToLower("A"));
+    }
+
+    SECTION("Two letters case") {
+        REQUIRE("aa" == Utils::Utils::ToLower("Aa"));
+    }
+
+    SECTION("CamelCase case") {
+        REQUIRE("camelcase" == Utils::Utils::ToLower("CamelCase"));
+    }
+
+    SECTION("snake_case case") {
+        REQUIRE("snake_case" == Utils::Utils::ToLower("snake_case"));
+    }
+
+    SECTION("More than one word case") {
+        REQUIRE("more than one word case" == Utils::Utils::ToLower("More than One Word case"));
+    }
+
+    SECTION("Special symbol case") {
+        REQUIRE("special symbol case????" == Utils::Utils::ToLower("Special symbol case????"));
+    }
+}
+
+TEST_CASE("Utils Split") {
+    SECTION("Empty string case") {
+        REQUIRE(Utils::Utils::Split("").empty());
+    }
+
+    SECTION("Only one letter case") {
+        const auto result = Utils::Utils::Split("A");
+        CHECK(!result.empty());
+        REQUIRE(1 == result.size());
+        REQUIRE("A" == result.at(0));
+    }
+
+    SECTION("Multiple elements case") {
+        const auto result = Utils::Utils::Split("A B C");
+        CHECK(!result.empty());
+        REQUIRE(3 == result.size());
+        REQUIRE("A" == result.at(0));
+        REQUIRE("B" == result.at(1));
+        REQUIRE("C" == result.at(2));
+    }
+
+    SECTION("Multiple elements case, semicolon separator") {
+        const auto result = Utils::Utils::Split("A;B C", ';');
+        CHECK(!result.empty());
+        REQUIRE(2 == result.size());
+        REQUIRE("A" == result.at(0));
+        REQUIRE("B C" == result.at(1));
+    }
+}
+
+TEST_CASE("Utils Contains") {
+    const std::vector<std::string> inputData = {"a", "b"};
+
+    SECTION("Empty vector case") {
+        REQUIRE(!Utils::Utils::Contains(std::vector<std::string>(), "st"));
+    }
+
+    SECTION("Empty string case") {
+        REQUIRE(!Utils::Utils::Contains(inputData, ""));
+    }
+
+    SECTION("Return false case") {
+        REQUIRE(!Utils::Utils::Contains(inputData, "st"));
+    }
+
+    SECTION("Return true case") {
+        REQUIRE(Utils::Utils::Contains(inputData, "a"));
+    }
+}
+
+TEST_CASE("Utils RemoveSpecialCharacters") {
+    SECTION("Empty string case") {
+        REQUIRE(Utils::Utils::RemoveSpecialCharacters("").empty());
+    }
+
+    SECTION("Do not delete any character") {
+        REQUIRE("something" == Utils::Utils::RemoveSpecialCharacters("something"));
+    }
+
+    SECTION("Delete '.' at the end") {
+        REQUIRE("something" == Utils::Utils::RemoveSpecialCharacters("something."));
+    }
+
+    SECTION("Delete '.' at the begin") {
+        REQUIRE("something" == Utils::Utils::RemoveSpecialCharacters(".something"));
+    }
+
+    SECTION("Delete '.' in the middle") {
+        REQUIRE("something" == Utils::Utils::RemoveSpecialCharacters("somet.hing"));
+    }
+
+    SECTION("Delete '.' on the ends") {
+        REQUIRE("something" == Utils::Utils::RemoveSpecialCharacters(".something."));
+    }
+
+    SECTION("Delete '.' on the ends and middle") {
+        REQUIRE("something" == Utils::Utils::RemoveSpecialCharacters(".somet.hing."));
+    }
+
+SECTION("Delete multiple characters") {
+        REQUIRE("something" == Utils::Utils::RemoveSpecialCharacters(".somet.h????ing."));
+    }
+}
 
 TEST_CASE("Intent Executor returns actions", "[Intent-Executor]" ) {
     ConsoleIntentRecognizer::IntentExecutor intentExecutor;
@@ -28,14 +143,18 @@ TEST_CASE("NLP Wrapper categorizes actions", "[NLP-Wrapper]" ) {
     ConsoleIntentRecognizer::NlpWrapper nlpWrapper;
 
     SECTION("Weather") {
-        REQUIRE(ConsoleIntentRecognizer::UNSUPPORTED == nlpWrapper.CategorizeAction("What is the weather like today?"));
+        REQUIRE(ConsoleIntentRecognizer::WEATHER == nlpWrapper.CategorizeAction("What is the weather like today?"));
     }
 
     SECTION("Weather City") {
-        REQUIRE(ConsoleIntentRecognizer::UNSUPPORTED == nlpWrapper.CategorizeAction("What is the weather like in Paris today?"));
+        REQUIRE(ConsoleIntentRecognizer::CITY_WEATHER == nlpWrapper.CategorizeAction("What is the weather like in Paris today?"));
     }
 
     SECTION("Fact") {
-        REQUIRE(ConsoleIntentRecognizer::UNSUPPORTED == nlpWrapper.CategorizeAction("Tell me an interesting fact."));
+        REQUIRE(ConsoleIntentRecognizer::FACT == nlpWrapper.CategorizeAction("Tell me an interesting fact."));
+    }
+
+    SECTION("Unsupported") {
+        REQUIRE(ConsoleIntentRecognizer::UNSUPPORTED == nlpWrapper.CategorizeAction("Hello World!!"));
     }
 }


### PR DESCRIPTION
A simple implementation of intent recognizer has been done. This approach is not considering an NLP (natural language processing). However, the main changes are as follows:
- Command-line tool.
- Compilation using CMake.
- Catch2 unit testing.